### PR TITLE
[ci] use ci-image rust

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ define run_cmd
 	then \
 		$(1); \
 	else \
-		docker run --rm --user "$(id -u)":"$(id -g)" --volume "${PWD}":/tmp/workspace --workdir /tmp/workspace rust:latest sh -c "$(1)"; \
+		docker run --rm --user "$(id -u)":"$(id -g)" --volume "${PWD}":/tmp/workspace --workdir /tmp/workspace kisiodigital/rust-ci:latest sh -c "$(1)"; \
 	fi
 endef
 


### PR DESCRIPTION
Goal is to avoid leaking files with wrong permissions on CI host agent (via `CARGO_TARGET_DIR`).