### PR TITLE
[feature] support for 'tracing' alongside 'log'

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,6 +62,16 @@ jobs:
       with:
         command: test
         args: --workspace --verbose
+    - name: Run tests with 'log' feature
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --verbose --features log
+    - name: Run tests with 'tracing' feature
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --verbose --features tracing
     - name: Run tests with all features
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,25 @@
 [package]
 name = "skip_error"
-version = "1.1.0"
+version = "2.0.0"
 license = "MIT"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
-description = "A macro to help skip an iteration in a loop from a Result"
+description = "Utility helping skip and log Result::Error in iterations"
 edition = "2018"
 homepage = "https://github.com/CanalTP/skip_error"
 repository = "https://github.com/CanalTP/skip_error"
 documentation = "https://docs.rs/skip_error"
 readme = "README.md"
-categories = ["rust-patterns"]
-keywords = ["macro", "log"]
+categories = ["development-tools::debugging", "rust-patterns"]
+keywords = ["macro", "log", "tracing"]
 
 [dependencies]
 log = { version = "0.4", optional = true }
+tracing = { version = "0.1", features = ["log"], optional = true }
+
+[dev-dependencies]
+log = "0.4"
+testing_logger = "0.1"
 
 [package.metadata.docs.rs]
 all-features = true
+


### PR DESCRIPTION
`skip_error` only supports `log` at the moment. This PR brings support for `tracing` as well as a _feature_. Note that in case of both _features_ being present, `tracing` is chosen (since it brings a compatibility with `log`, this shouldn't cause any problem).