### PR TITLE
[feature] define shortcut macros for skip_error_and_log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skip_error"
-version = "2.1.0"
+version = "3.0.0"
 license = "MIT"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 description = "Utility helping skip and log Result::Error in iterations"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skip_error"
-version = "2.0.0"
+version = "2.1.0"
 license = "MIT"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 description = "Utility helping skip and log Result::Error in iterations"

--- a/README.md
+++ b/README.md
@@ -7,5 +7,10 @@
 [crates.io]: https://crates.io/crates/skip_error                
 
 # skip_error
+
 `skip_error` provides a single macro to help ignoring `Error` that would happen
 in a loop. See [documentation](https://docs.rs/skip_error) to know more.
+
+## Rust version requirement
+
+`skip_error` 3.0.0 requires **Rustc version 1.54 or greater**.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,12 +40,16 @@
 //! # }
 //! ```
 //!
-//! # Logging
-//!
-//! If you want the error to be logged, you can use the feature `log` or the
-//! feature `tracing` (see [Features](#features)). See [`skip_error_and_log!`]
-//! and [`SkipError::skip_error_and_log()`] for more information.
-//!
+#![cfg_attr(
+    any(feature = "log", feature = "tracing"),
+    doc = "
+# Logging
+
+If you want the error to be logged, you can use the feature `log` or the
+feature `tracing` (see [Features](#features)). See [`skip_error_and_log!`]
+and [`SkipError::skip_error_and_log()`] for more information.
+"
+)]
 //! # Features
 //!
 //! - `log`: emit log message with the standard `std::log` macro. Disabled by
@@ -55,11 +59,11 @@
 //! ignored since `tracing` is configured in a compatibility mode with standard
 //! `log`.
 
-/// `skip_error` returns the value of a `Result` or continues a loop.
+/// `skip_error` returns the value of a [`Result`] or continues a loop.
 ///
-/// `skip_error` macro takes one parameter of type `std::result::Result`. It
-/// returns the value if `Result::Ok` or else, it calls `continue` and ignore
-/// the `Result::Error`.
+/// `skip_error` macro takes one parameter of type [`Result`]. It returns the
+/// value if [`Result::Ok`] or else, it calls `continue` and ignore the
+/// [`Result::Err`].
 ///
 /// For example
 /// ```edition2018
@@ -83,14 +87,15 @@ macro_rules! skip_error {
     }};
 }
 
-/// `skip_error_and_log` returns the value of a `Result` or log and continues a
-/// loop.
+/// `skip_error_and_log` returns the value of a [`Result`] or log and continues
+/// the loop.
 ///
 /// `skip_error_and_log` macro takes two parameters. The first argument is of
-/// type `std::result::Result`. The second argument is anything that can be
-/// turned into `log::Level` (feature `log`) or `tracing::Level` (feature
-/// `tracing`) and defines the level to log to.  The macro returns the value if
-/// `Result::Ok` and else, it logs the `Result::Error` and calls `continue`.
+/// type [`Result`]. The second argument is anything that can be turned into
+#[cfg_attr(all(feature = "log", not(feature = "tracing")), doc = "[`log::Level`]")]
+#[cfg_attr(feature = "tracing", doc = "[`tracing::Level`]")]
+/// and defines the level to log to.  The macro returns the value if
+/// [`Result::Ok`] and else, it logs the [`Result::Err`] and calls `continue`.
 ///
 /// For example
 /// ```edition2018

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,16 +133,6 @@ macro_rules! skip_error_and_log {
     }};
 }
 
-// From https://docs.rs/doc-comment but only the interesting part
-// Allow us to document our generated macros
-#[cfg(any(feature = "log", feature = "tracing"))]
-macro_rules! doc_comment {
-    ($x:expr,  $($tt:tt)*) => {
-        #[doc = $x]
-        $($tt)*
-    };
-}
-
 // Macro to generate new macros
 #[cfg(any(feature = "log", feature = "tracing"))]
 macro_rules! skip_error_macro_generation {
@@ -150,44 +140,40 @@ macro_rules! skip_error_macro_generation {
         skip_error_macro_generation!($macro_name, $log_level, $log_level);
     };
     ($macro_name:ident, $log_level:expr, $expected_log_level:expr) => {
-        doc_comment! {
-            // Start the comment of the generated macro
-            concat!(
-                "`",
-                stringify!($macro_name),
-                "` returns the value of a [`Result`] or log with [`",
-                stringify!($log_level),
-                "`] and continues the loop.\n\n",
-                "`",
-                stringify!($macro_name),
-                "` macro takes one parameter which is of type [`Result`].",
-                "The macro returns the value if `Result::Ok` and else,",
-                "it logs the [`Result::Err`] with level [`",
-                stringify!($log_level),
-                "`] and calls `continue`.\n\n",
-                "For example\n",
-                "```edition2018\n",
-                "# #[macro_use]\n",
-                "# extern crate skip_error;\n",
-                "# fn main() {\n",
-                "# testing_logger::setup();\n",
-                "for string_number in &[\"1\", \"2\", \"three\", \"4\"] {\n",
-                "  let number: u32 = ", stringify!($macro_name), "!(string_number.parse());\n",
-                "}\n",
-                "testing_logger::validate(|captured_logs| {\n",
-                "  assert!(captured_logs[0].body.contains(\"invalid digit found in string\"));\n",
-                "  assert_eq!(captured_logs[0].level, ", stringify!($expected_log_level), ");\n",
-                "});\n",
-                "# }\n",
-                "```\n",
-            ),
-            // Start the macro definition
-            #[macro_export]
-            macro_rules! $macro_name {
-                ($result:expr) => {{
-                    skip_error_and_log!($result, $log_level)
-                }};
-            }
+        #[doc = concat!(
+            "`",
+            stringify!($macro_name),
+            "` returns the value of a [`Result`] or log with [`",
+            stringify!($log_level),
+            "`] and continues the loop.\n\n",
+            "`",
+            stringify!($macro_name),
+            "` macro takes one parameter which is of type [`Result`].",
+            "The macro returns the value if `Result::Ok` and else,",
+            "it logs the [`Result::Err`] with level [`",
+            stringify!($log_level),
+            "`] and calls `continue`.\n\n",
+            "For example\n",
+            "```edition2018\n",
+            "# #[macro_use]\n",
+            "# extern crate skip_error;\n",
+            "# fn main() {\n",
+            "# testing_logger::setup();\n",
+            "for string_number in &[\"1\", \"2\", \"three\", \"4\"] {\n",
+            "  let number: u32 = ", stringify!($macro_name), "!(string_number.parse());\n",
+            "}\n",
+            "testing_logger::validate(|captured_logs| {\n",
+            "  assert!(captured_logs[0].body.contains(\"invalid digit found in string\"));\n",
+            "  assert_eq!(captured_logs[0].level, ", stringify!($expected_log_level), ");\n",
+            "});\n",
+            "# }\n",
+            "```\n",
+        )]
+        #[macro_export]
+        macro_rules! $macro_name {
+            ($result:expr) => {{
+                skip_error_and_log!($result, $log_level)
+            }};
         }
     };
 }


### PR DESCRIPTION
Defines these new shortcut macros:
- `skip_error_and_error`
- `skip_error_and_warn`
- `skip_error_and_info`
- `skip_error_and_debug`
- `skip_error_and_trace`

Also made a bunch of improvements to the documentation.