### PR TITLE
[feature] add shortcuts to the iterator methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skip_error"
-version = "3.0.0"
+version = "3.1.0"
 license = "MIT"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 description = "Utility helping skip and log Result::Error in iterations"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,34 @@ where
     }
 }
 
+#[cfg(any(feature = "log", feature = "tracing"))]
+macro_rules! default_impl_skip_error_iterator {
+    ($method_name:ident,$log_level:expr) => {
+        #[doc = concat!(
+                            "Shortcut for [`SkipError::skip_error_and_log`] with a log level of [`",
+                            stringify!($log_level),
+                            "`].\n\n",
+                            "For example\n",
+                            "```edition2018\n",
+                            "use skip_error::SkipError;\n",
+                            "# fn main() {\n",
+                            "# testing_logger::setup();\n",
+                            "vec![Ok(1), Ok(2), Err(\"'three' is not a valid number\"), Ok(4)]\n",
+                            "  .into_iter()\n",
+                            "  .skip_error_and_debug()\n",
+                            "  .collect::<Vec<_>>();\n",
+                            "testing_logger::validate(|captured_logs| {\n",
+                            "  assert!(captured_logs[0].body.contains(\"'three' is not a valid number\"));\n",
+                            "});\n",
+                            "# }\n",
+                            "```\n"
+                        )]
+        fn $method_name(self) -> SkipErrorIter<I, T, E> {
+            self.skip_error_and_log($log_level)
+        }
+    };
+}
+
 /// Trait to extend any [`Iterator`] where the [`Iterator::Item`] is a [`Result`].
 /// This allows to skip errors and keep only the `Ok()` values.
 pub trait SkipError<I, T, E>: Sized
@@ -357,6 +385,27 @@ where
     fn skip_error_and_log<L>(self, trace_level: L) -> SkipErrorIter<I, T, E>
     where
         L: Into<tracing::Level>;
+
+    #[cfg(all(feature = "log", not(feature = "tracing")))]
+    default_impl_skip_error_iterator!(skip_error_and_trace, log::Level::Trace);
+    #[cfg(all(feature = "log", not(feature = "tracing")))]
+    default_impl_skip_error_iterator!(skip_error_and_debug, log::Level::Debug);
+    #[cfg(all(feature = "log", not(feature = "tracing")))]
+    default_impl_skip_error_iterator!(skip_error_and_error, log::Level::Error);
+    #[cfg(all(feature = "log", not(feature = "tracing")))]
+    default_impl_skip_error_iterator!(skip_error_and_warn, log::Level::Warn);
+    #[cfg(all(feature = "log", not(feature = "tracing")))]
+    default_impl_skip_error_iterator!(skip_error_and_info, log::Level::Info);
+    #[cfg(feature = "tracing")]
+    default_impl_skip_error_iterator!(skip_error_and_trace, tracing::Level::TRACE);
+    #[cfg(feature = "tracing")]
+    default_impl_skip_error_iterator!(skip_error_and_debug, tracing::Level::DEBUG);
+    #[cfg(feature = "tracing")]
+    default_impl_skip_error_iterator!(skip_error_and_error, tracing::Level::ERROR);
+    #[cfg(feature = "tracing")]
+    default_impl_skip_error_iterator!(skip_error_and_warn, tracing::Level::WARN);
+    #[cfg(feature = "tracing")]
+    default_impl_skip_error_iterator!(skip_error_and_info, tracing::Level::INFO);
 }
 
 impl<I, T, E> SkipError<I, T, E> for I

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ macro_rules! default_impl_skip_error_iterator {
                             "# testing_logger::setup();\n",
                             "vec![Ok(1), Ok(2), Err(\"'three' is not a valid number\"), Ok(4)]\n",
                             "  .into_iter()\n",
-                            "  .skip_error_and_debug()\n",
+                            "  .", stringify!($method_name), "()\n",
                             "  .collect::<Vec<_>>();\n",
                             "testing_logger::validate(|captured_logs| {\n",
                             "  assert!(captured_logs[0].body.contains(\"'three' is not a valid number\"));\n",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,25 +279,25 @@ macro_rules! default_impl_skip_error_iterator {
     };
     ($method_name:ident, $log_level:expr, $expected_log_level:expr) => {
         #[doc = concat!(
-                            "Shortcut for [`SkipError::skip_error_and_log`] with a log level of [`",
-                            stringify!($log_level),
-                            "`].\n\n",
-                            "For example\n",
-                            "```edition2018\n",
-                            "use skip_error::SkipError;\n",
-                            "# fn main() {\n",
-                            "# testing_logger::setup();\n",
-                            "vec![Ok(1), Ok(2), Err(\"'three' is not a valid number\"), Ok(4)]\n",
-                            "  .into_iter()\n",
-                            "  .", stringify!($method_name), "()\n",
-                            "  .collect::<Vec<_>>();\n",
-                            "testing_logger::validate(|captured_logs| {\n",
-                            "  assert!(captured_logs[0].body.contains(\"'three' is not a valid number\"));\n",
-                            "  assert_eq!(captured_logs[0].level, ", stringify!($expected_log_level), ");\n",
-                            "});\n",
-                            "# }\n",
-                            "```\n"
-                        )]
+            "Shortcut for [`SkipError::skip_error_and_log`] with a log level of [`",
+            stringify!($log_level),
+            "`].\n\n",
+            "For example\n",
+            "```edition2018\n",
+            "use skip_error::SkipError;\n",
+            "# fn main() {\n",
+            "# testing_logger::setup();\n",
+            "vec![Ok(1), Ok(2), Err(\"'three' is not a valid number\"), Ok(4)]\n",
+            "  .into_iter()\n",
+            "  .", stringify!($method_name), "()\n",
+            "  .collect::<Vec<_>>();\n",
+            "testing_logger::validate(|captured_logs| {\n",
+            "  assert!(captured_logs[0].body.contains(\"'three' is not a valid number\"));\n",
+            "  assert_eq!(captured_logs[0].level, ", stringify!($expected_log_level), ");\n",
+            "});\n",
+            "# }\n",
+            "```\n"
+        )]
         fn $method_name(self) -> SkipErrorIter<I, T, E> {
             self.skip_error_and_log($log_level)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,10 @@ where
 
 #[cfg(any(feature = "log", feature = "tracing"))]
 macro_rules! default_impl_skip_error_iterator {
-    ($method_name:ident,$log_level:expr) => {
+    ($method_name:ident, $log_level:expr) => {
+        default_impl_skip_error_iterator!($method_name, $log_level, $log_level);
+    };
+    ($method_name:ident, $log_level:expr, $expected_log_level:expr) => {
         #[doc = concat!(
                             "Shortcut for [`SkipError::skip_error_and_log`] with a log level of [`",
                             stringify!($log_level),
@@ -290,6 +293,7 @@ macro_rules! default_impl_skip_error_iterator {
                             "  .collect::<Vec<_>>();\n",
                             "testing_logger::validate(|captured_logs| {\n",
                             "  assert!(captured_logs[0].body.contains(\"'three' is not a valid number\"));\n",
+                            "  assert_eq!(captured_logs[0].level, ", stringify!($expected_log_level), ");\n",
                             "});\n",
                             "# }\n",
                             "```\n"
@@ -397,15 +401,27 @@ where
     #[cfg(all(feature = "log", not(feature = "tracing")))]
     default_impl_skip_error_iterator!(skip_error_and_info, log::Level::Info);
     #[cfg(feature = "tracing")]
-    default_impl_skip_error_iterator!(skip_error_and_trace, tracing::Level::TRACE);
+    default_impl_skip_error_iterator!(
+        skip_error_and_trace,
+        tracing::Level::TRACE,
+        log::Level::Trace
+    );
     #[cfg(feature = "tracing")]
-    default_impl_skip_error_iterator!(skip_error_and_debug, tracing::Level::DEBUG);
+    default_impl_skip_error_iterator!(
+        skip_error_and_debug,
+        tracing::Level::DEBUG,
+        log::Level::Debug
+    );
     #[cfg(feature = "tracing")]
-    default_impl_skip_error_iterator!(skip_error_and_error, tracing::Level::ERROR);
+    default_impl_skip_error_iterator!(
+        skip_error_and_error,
+        tracing::Level::ERROR,
+        log::Level::Error
+    );
     #[cfg(feature = "tracing")]
-    default_impl_skip_error_iterator!(skip_error_and_warn, tracing::Level::WARN);
+    default_impl_skip_error_iterator!(skip_error_and_warn, tracing::Level::WARN, log::Level::Warn);
     #[cfg(feature = "tracing")]
-    default_impl_skip_error_iterator!(skip_error_and_info, tracing::Level::INFO);
+    default_impl_skip_error_iterator!(skip_error_and_info, tracing::Level::INFO, log::Level::Info);
 }
 
 impl<I, T, E> SkipError<I, T, E> for I


### PR DESCRIPTION
Follow-up of the PR on https://github.com/CanalTP/skip_error/pull/11 where we provide shortcuts for the macro. This PR is doing the same work for the iterator's methods.

Note: I choose to do it with a copy/paste solution, but I could do it with a macro to factorize code. If you think it'd be better with a macro, I'd be happy to do it, so don't hesitate to ping me on this.