### PR TITLE
[fix] when used externally, brings 'skip_error_and_log' in scope

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skip_error"
-version = "3.1.0"
+version = "3.1.1"
 license = "MIT"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 description = "Utility helping skip and log Result::Error in iterations"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ macro_rules! skip_error_macro_generation {
         #[macro_export]
         macro_rules! $macro_name {
             ($result:expr) => {{
-                skip_error_and_log!($result, $log_level)
+                $crate::skip_error_and_log!($result, $log_level)
             }};
         }
     };


### PR DESCRIPTION
Without this, `skip_error_and_log` seems to be not visible when a macro like `skip_error_and_warn` is used. This means that code expansion does work, but then compilation failed because it can find a valid `skip_error_and_log` macro in scope. This qualified path will fix this problem.